### PR TITLE
Add build script and documentation for automated plugin packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 # Backup files
 *.bak
 *.backup
+wp-tracker.php.backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Build artifacts and packages
+*.zip
+wp-tracker-plugin/
+build/
+dist/
+
+# Temporary files
+*.tmp
+*.temp
+*.swp
+*.swo
+*~
+
+# IDE and editor files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Node modules (if you add any build tools later)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Backup files
+*.bak
+*.backup

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,26 @@ This will:
 4. Copy all necessary files
 5. Create a ZIP package with the current version
 
+## Version Management
+
+The build script can automatically increment the plugin version:
+
+```bash
+# Increment patch version (1.0.0 → 1.0.1)
+./build.sh --patch
+
+# Increment minor version (1.0.0 → 1.1.0)
+./build.sh --minor
+
+# Increment major version (1.0.0 → 2.0.0)
+./build.sh --major
+```
+
+When using version increments:
+- The script automatically updates the version in `wp-tracker.php`
+- A backup of the original file is created (`wp-tracker.php.backup`)
+- The new package is built with the updated version
+
 ## Build Output
 
 The build script creates:
@@ -30,15 +50,15 @@ The build script automatically reads the version from the plugin header in `wp-t
 ```php
 /**
  * Plugin Name: WP Tracker
- * Version: 1.0.0
+ * Version: 1.0.1
  * ...
  */
 ```
 
-To update the version:
-1. Edit the `Version:` line in `wp-tracker.php`
-2. Run `./build.sh`
-3. The new package will be created with the updated version
+The script supports semantic versioning increments:
+- **Patch**: Bug fixes and minor updates (1.0.0 → 1.0.1)
+- **Minor**: New features, backward compatible (1.0.0 → 1.1.0)  
+- **Major**: Breaking changes (1.0.0 → 2.0.0)
 
 ## File Structure
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,63 @@
+# WP Tracker Build Process
+
+This document explains how to build the WP Tracker plugin for distribution.
+
+## Quick Build
+
+To create a plugin package, simply run:
+
+```bash
+./build.sh
+```
+
+This will:
+1. Validate the plugin file
+2. Clean previous builds
+3. Create a clean build structure
+4. Copy all necessary files
+5. Create a ZIP package with the current version
+
+## Build Output
+
+The build script creates:
+- `build/` - Temporary build directory
+- `wp-tracker-v{version}.zip` - Plugin package ready for distribution
+
+## Version Management
+
+The build script automatically reads the version from the plugin header in `wp-tracker.php`:
+
+```php
+/**
+ * Plugin Name: WP Tracker
+ * Version: 1.0.0
+ * ...
+ */
+```
+
+To update the version:
+1. Edit the `Version:` line in `wp-tracker.php`
+2. Run `./build.sh`
+3. The new package will be created with the updated version
+
+## File Structure
+
+The build includes:
+- `wp-tracker.php` - Main plugin file
+- `README.md` - Plugin documentation
+- `uninstall.php` - Uninstall script (if exists)
+- `assets/` - CSS, JS, images (if exists)
+- `includes/` - PHP includes (if exists)
+
+## Requirements
+
+- Bash shell
+- `zip` command (usually pre-installed on macOS/Linux)
+- Git (for version control)
+
+## Troubleshooting
+
+If the build fails:
+1. Check that `wp-tracker.php` exists and has a valid plugin header
+2. Ensure the version is properly set in the plugin header
+3. Verify you have write permissions in the current directory

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# WP Tracker Plugin Build Script
+# This script creates a clean plugin package for distribution
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+PLUGIN_NAME="wp-tracker"
+BUILD_DIR="build"
+PLUGIN_DIR="$BUILD_DIR/$PLUGIN_NAME"
+
+# Get version from plugin file
+get_version() {
+    local version=$(grep "Version:" wp-tracker.php | sed 's/.*Version: *//' | tr -d ' ')
+    echo "$version"
+}
+
+# Clean previous builds
+clean_build() {
+    echo -e "${BLUE}🧹 Cleaning previous builds...${NC}"
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+    fi
+    if [ -f "${PLUGIN_NAME}-v*.zip" ]; then
+        rm -f "${PLUGIN_NAME}-v*.zip"
+    fi
+}
+
+# Create build directory structure
+create_build_structure() {
+    echo -e "${BLUE}📁 Creating build structure...${NC}"
+    mkdir -p "$PLUGIN_DIR"
+}
+
+# Copy plugin files
+copy_files() {
+    echo -e "${BLUE}📋 Copying plugin files...${NC}"
+    cp wp-tracker.php "$PLUGIN_DIR/"
+    cp README.md "$PLUGIN_DIR/"
+    
+    # Copy any additional files if they exist
+    if [ -f "uninstall.php" ]; then
+        cp uninstall.php "$PLUGIN_DIR/"
+    fi
+    
+    if [ -d "assets" ]; then
+        cp -r assets "$PLUGIN_DIR/"
+    fi
+    
+    if [ -d "includes" ]; then
+        cp -r includes "$PLUGIN_DIR/"
+    fi
+}
+
+# Create ZIP package
+create_package() {
+    local version=$(get_version)
+    local zip_name="${PLUGIN_NAME}-v${version}.zip"
+    
+    echo -e "${BLUE}📦 Creating package: $zip_name${NC}"
+    
+    cd "$BUILD_DIR"
+    zip -r "../$zip_name" "$PLUGIN_NAME" -x "*.DS_Store" "*/.*"
+    cd ..
+    
+    echo -e "${GREEN}✅ Package created: $zip_name${NC}"
+    echo -e "${YELLOW}📊 Package size: $(du -h "$zip_name" | cut -f1)${NC}"
+}
+
+# Validate plugin file
+validate_plugin() {
+    echo -e "${BLUE}🔍 Validating plugin file...${NC}"
+    
+    if [ ! -f "wp-tracker.php" ]; then
+        echo -e "${RED}❌ Error: wp-tracker.php not found${NC}"
+        exit 1
+    fi
+    
+    if ! grep -q "Plugin Name:" wp-tracker.php; then
+        echo -e "${RED}❌ Error: Plugin header not found in wp-tracker.php${NC}"
+        exit 1
+    fi
+    
+    local version=$(get_version)
+    if [ -z "$version" ]; then
+        echo -e "${RED}❌ Error: Version not found in plugin header${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}✅ Plugin validation passed (Version: $version)${NC}"
+}
+
+# Main build process
+main() {
+    echo -e "${BLUE}🚀 Starting WP Tracker build process...${NC}"
+    echo ""
+    
+    validate_plugin
+    clean_build
+    create_build_structure
+    copy_files
+    create_package
+    
+    echo ""
+    echo -e "${GREEN}🎉 Build completed successfully!${NC}"
+    echo -e "${YELLOW}📁 Build directory: $BUILD_DIR${NC}"
+    echo -e "${YELLOW}📦 Package: $(ls ${PLUGIN_NAME}-v*.zip)${NC}"
+}
+
+# Run main function
+main "$@"

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,78 @@ get_version() {
     echo "$version"
 }
 
+# Calculate new version based on increment type
+calculate_new_version() {
+    local current_version="$1"
+    local increment_type="$2"
+    
+    # Parse current version (assuming format: major.minor.patch)
+    IFS='.' read -ra VERSION_PARTS <<< "$current_version"
+    local major="${VERSION_PARTS[0]:-0}"
+    local minor="${VERSION_PARTS[1]:-0}"
+    local patch="${VERSION_PARTS[2]:-0}"
+    
+    case "$increment_type" in
+        major)
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        minor)
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        patch)
+            patch=$((patch + 1))
+            ;;
+        *)
+            echo -e "${RED}❌ Error: Invalid increment type. Use 'major', 'minor', or 'patch'${NC}"
+            exit 1
+            ;;
+    esac
+    
+    echo "${major}.${minor}.${patch}"
+}
+
+# Update version in plugin file
+update_version() {
+    local increment_type="$1"
+    local current_version=$(get_version)
+    local new_version=$(calculate_new_version "$current_version" "$increment_type")
+    local temp_file="wp-tracker.php.tmp"
+    
+    echo -e "${BLUE}📝 Updating version from $current_version to $new_version ($increment_type increment)${NC}"
+    
+    # Create backup
+    cp wp-tracker.php "wp-tracker.php.backup"
+    
+    # Update version in file
+    sed "s/Version: [0-9.]*/Version: $new_version/" wp-tracker.php > "$temp_file"
+    mv "$temp_file" wp-tracker.php
+    
+    echo -e "${GREEN}✅ Version updated successfully${NC}"
+}
+
+# Show usage information
+show_usage() {
+    echo -e "${BLUE}WP Tracker Build Script${NC}"
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --major                 Increment major version (1.0.0 → 2.0.0)"
+    echo "  --minor                 Increment minor version (1.0.0 → 1.1.0)"
+    echo "  --patch                 Increment patch version (1.0.0 → 1.0.1)"
+    echo "  -h, --help              Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                      Build with current version"
+    echo "  $0 --patch              Increment patch version and build"
+    echo "  $0 --minor              Increment minor version and build"
+    echo "  $0 --major              Increment major version and build"
+    echo ""
+}
+
 # Clean previous builds
 clean_build() {
     echo -e "${BLUE}🧹 Cleaning previous builds...${NC}"
@@ -100,8 +172,35 @@ validate_plugin() {
 
 # Main build process
 main() {
+    local increment_type=""
+    
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --major|--minor|--patch)
+                increment_type="${1#--}"  # Remove the -- prefix
+                shift
+                ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}❌ Unknown option: $1${NC}"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+    
     echo -e "${BLUE}🚀 Starting WP Tracker build process...${NC}"
     echo ""
+    
+    # Update version if specified
+    if [ -n "$increment_type" ]; then
+        update_version "$increment_type"
+        echo ""
+    fi
     
     validate_plugin
     clean_build
@@ -113,6 +212,11 @@ main() {
     echo -e "${GREEN}🎉 Build completed successfully!${NC}"
     echo -e "${YELLOW}📁 Build directory: $BUILD_DIR${NC}"
     echo -e "${YELLOW}📦 Package: $(ls ${PLUGIN_NAME}-v*.zip)${NC}"
+    
+    # Show backup info if version was updated
+    if [ -n "$increment_type" ]; then
+        echo -e "${YELLOW}💾 Backup created: wp-tracker.php.backup${NC}"
+    fi
 }
 
 # Run main function

--- a/wp-tracker.php
+++ b/wp-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Tracker
  * Plugin URI: https://github.com/yourusername/wp-tracker
  * Description: Create tracker links that count clicks and redirect to destination URLs
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Your Name
  * License: GPL v2 or later
  * Text Domain: wp-tracker


### PR DESCRIPTION
This PR adds a comprehensive build system for the WP Tracker plugin: - **build.sh**: Automated build script that creates clean plugin packages - **BUILD.md**: Documentation explaining the build process - **Updated .gitignore**: Excludes build artifacts from version control The build script automatically reads the version from the plugin header and creates properly structured ZIP packages ready for distribution.