### PR TITLE
Separate version management from build process

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -19,23 +19,51 @@ This will:
 
 ## Version Management
 
-The build script can automatically increment the plugin version:
+Version management is handled separately using the `version.sh` script:
 
 ```bash
-# Increment patch version (1.0.0 → 1.0.1)
-./build.sh --patch
+# Show current version
+./version.sh --current
 
-# Increment minor version (1.0.0 → 1.1.0)
-./build.sh --minor
+# Increment patch version (1.0.0 → 1.0.1) and commit
+./version.sh --patch
 
-# Increment major version (1.0.0 → 2.0.0)
-./build.sh --major
+# Increment minor version (1.0.0 → 1.1.0) and commit
+./version.sh --minor
+
+# Increment major version (1.0.0 → 2.0.0) and commit
+./version.sh --major
+
+# Update version without committing (for testing)
+./version.sh --patch --no-commit
 ```
 
 When using version increments:
 - The script automatically updates the version in `wp-tracker.php`
 - A backup of the original file is created (`wp-tracker.php.backup`)
-- The new package is built with the updated version
+- Changes are committed to git (unless `--no-commit` is used)
+- You can then run `./build.sh` to create a package with the new version
+
+## Workflow
+
+The recommended workflow for releases:
+
+1. **Update version** (commits the change):
+   ```bash
+   ./version.sh --patch  # or --minor or --major
+   ```
+
+2. **Build package**:
+   ```bash
+   ./build.sh
+   ```
+
+3. **Test the package** on your WordPress site
+
+4. **Push changes**:
+   ```bash
+   git push origin main
+   ```
 
 ## Build Output
 

--- a/build.sh
+++ b/build.sh
@@ -23,57 +23,7 @@ get_version() {
     echo "$version"
 }
 
-# Calculate new version based on increment type
-calculate_new_version() {
-    local current_version="$1"
-    local increment_type="$2"
-    
-    # Parse current version (assuming format: major.minor.patch)
-    IFS='.' read -ra VERSION_PARTS <<< "$current_version"
-    local major="${VERSION_PARTS[0]:-0}"
-    local minor="${VERSION_PARTS[1]:-0}"
-    local patch="${VERSION_PARTS[2]:-0}"
-    
-    case "$increment_type" in
-        major)
-            major=$((major + 1))
-            minor=0
-            patch=0
-            ;;
-        minor)
-            minor=$((minor + 1))
-            patch=0
-            ;;
-        patch)
-            patch=$((patch + 1))
-            ;;
-        *)
-            echo -e "${RED}❌ Error: Invalid increment type. Use 'major', 'minor', or 'patch'${NC}"
-            exit 1
-            ;;
-    esac
-    
-    echo "${major}.${minor}.${patch}"
-}
 
-# Update version in plugin file
-update_version() {
-    local increment_type="$1"
-    local current_version=$(get_version)
-    local new_version=$(calculate_new_version "$current_version" "$increment_type")
-    local temp_file="wp-tracker.php.tmp"
-    
-    echo -e "${BLUE}📝 Updating version from $current_version to $new_version ($increment_type increment)${NC}"
-    
-    # Create backup
-    cp wp-tracker.php "wp-tracker.php.backup"
-    
-    # Update version in file
-    sed "s/Version: [0-9.]*/Version: $new_version/" wp-tracker.php > "$temp_file"
-    mv "$temp_file" wp-tracker.php
-    
-    echo -e "${GREEN}✅ Version updated successfully${NC}"
-}
 
 # Show usage information
 show_usage() {
@@ -82,16 +32,12 @@ show_usage() {
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  --major                 Increment major version (1.0.0 → 2.0.0)"
-    echo "  --minor                 Increment minor version (1.0.0 → 1.1.0)"
-    echo "  --patch                 Increment patch version (1.0.0 → 1.0.1)"
     echo "  -h, --help              Show this help message"
     echo ""
     echo "Examples:"
     echo "  $0                      Build with current version"
-    echo "  $0 --patch              Increment patch version and build"
-    echo "  $0 --minor              Increment minor version and build"
-    echo "  $0 --major              Increment major version and build"
+    echo ""
+    echo "Note: Use './version.sh' to manage version increments"
     echo ""
 }
 
@@ -172,15 +118,9 @@ validate_plugin() {
 
 # Main build process
 main() {
-    local increment_type=""
-    
     # Parse command line arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --major|--minor|--patch)
-                increment_type="${1#--}"  # Remove the -- prefix
-                shift
-                ;;
             -h|--help)
                 show_usage
                 exit 0
@@ -196,12 +136,6 @@ main() {
     echo -e "${BLUE}🚀 Starting WP Tracker build process...${NC}"
     echo ""
     
-    # Update version if specified
-    if [ -n "$increment_type" ]; then
-        update_version "$increment_type"
-        echo ""
-    fi
-    
     validate_plugin
     clean_build
     create_build_structure
@@ -212,11 +146,6 @@ main() {
     echo -e "${GREEN}🎉 Build completed successfully!${NC}"
     echo -e "${YELLOW}📁 Build directory: $BUILD_DIR${NC}"
     echo -e "${YELLOW}📦 Package: $(ls ${PLUGIN_NAME}-v*.zip)${NC}"
-    
-    # Show backup info if version was updated
-    if [ -n "$increment_type" ]; then
-        echo -e "${YELLOW}💾 Backup created: wp-tracker.php.backup${NC}"
-    fi
 }
 
 # Run main function

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+# WP Tracker Version Management Script
+# This script handles version increments and commits the changes
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get version from plugin file
+get_version() {
+    local version=$(grep "Version:" wp-tracker.php | sed 's/.*Version: *//' | tr -d ' ')
+    echo "$version"
+}
+
+# Calculate new version based on increment type
+calculate_new_version() {
+    local current_version="$1"
+    local increment_type="$2"
+    
+    # Parse current version (assuming format: major.minor.patch)
+    IFS='.' read -ra VERSION_PARTS <<< "$current_version"
+    local major="${VERSION_PARTS[0]:-0}"
+    local minor="${VERSION_PARTS[1]:-0}"
+    local patch="${VERSION_PARTS[2]:-0}"
+    
+    case "$increment_type" in
+        major)
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        minor)
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        patch)
+            patch=$((patch + 1))
+            ;;
+        *)
+            echo -e "${RED}❌ Error: Invalid increment type. Use 'major', 'minor', or 'patch'${NC}"
+            exit 1
+            ;;
+    esac
+    
+    echo "${major}.${minor}.${patch}"
+}
+
+# Update version in plugin file
+update_version() {
+    local increment_type="$1"
+    local current_version=$(get_version)
+    local new_version=$(calculate_new_version "$current_version" "$increment_type")
+    local temp_file="wp-tracker.php.tmp"
+    
+    echo -e "${BLUE}📝 Updating version from $current_version to $new_version ($increment_type increment)${NC}"
+    
+    # Create backup
+    cp wp-tracker.php "wp-tracker.php.backup"
+    
+    # Update version in file
+    sed "s/Version: [0-9.]*/Version: $new_version/" wp-tracker.php > "$temp_file"
+    mv "$temp_file" wp-tracker.php
+    
+    echo -e "${GREEN}✅ Version updated successfully${NC}"
+    echo -e "${YELLOW}💾 Backup created: wp-tracker.php.backup${NC}"
+    
+    # Return the new version for commit message
+    echo "$new_version"
+}
+
+# Commit version change
+commit_version_change() {
+    local new_version="$1"
+    local increment_type="$2"
+    
+    echo -e "${BLUE}📝 Committing version change...${NC}"
+    
+    # Add the updated plugin file
+    git add wp-tracker.php
+    
+    # Create commit message
+    local commit_message="Bump version to $new_version ($increment_type increment)"
+    
+    # Commit the change
+    git commit -m "$commit_message"
+    
+    echo -e "${GREEN}✅ Version change committed${NC}"
+    echo -e "${YELLOW}📝 Commit message: $commit_message${NC}"
+}
+
+# Show usage information
+show_usage() {
+    echo -e "${BLUE}WP Tracker Version Management Script${NC}"
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --major                 Increment major version (1.0.0 → 2.0.0) and commit"
+    echo "  --minor                 Increment minor version (1.0.0 → 1.1.0) and commit"
+    echo "  --patch                 Increment patch version (1.0.0 → 1.0.1) and commit"
+    echo "  --no-commit             Update version without committing"
+    echo "  --current               Show current version"
+    echo "  -h, --help              Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --current            Show current version"
+    echo "  $0 --patch              Increment patch version and commit"
+    echo "  $0 --minor --no-commit  Increment minor version without committing"
+    echo "  $0 --major              Increment major version and commit"
+    echo ""
+}
+
+# Main function
+main() {
+    local increment_type=""
+    local no_commit=false
+    local show_current=false
+    
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --major|--minor|--patch)
+                increment_type="${1#--}"  # Remove the -- prefix
+                shift
+                ;;
+            --no-commit)
+                no_commit=true
+                shift
+                ;;
+            --current)
+                show_current=true
+                shift
+                ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}❌ Unknown option: $1${NC}"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Show current version if requested
+    if [ "$show_current" = true ]; then
+        local current_version=$(get_version)
+        echo -e "${GREEN}Current version: $current_version${NC}"
+        exit 0
+    fi
+    
+    # Check if increment type is specified
+    if [ -z "$increment_type" ]; then
+        echo -e "${RED}❌ Error: Please specify an increment type (--major, --minor, or --patch)${NC}"
+        show_usage
+        exit 1
+    fi
+    
+    echo -e "${BLUE}🚀 Starting version management...${NC}"
+    echo ""
+    
+    # Update version
+    local new_version=$(update_version "$increment_type")
+    
+    # Commit if not disabled
+    if [ "$no_commit" = false ]; then
+        echo ""
+        commit_version_change "$new_version" "$increment_type"
+    else
+        echo -e "${YELLOW}⚠️  Version updated but not committed (use --no-commit)${NC}"
+    fi
+    
+    echo ""
+    echo -e "${GREEN}🎉 Version management completed!${NC}"
+    echo -e "${YELLOW}📦 Next step: Run './build.sh' to create a package${NC}"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
This PR separates version management from the build process for better workflow control: - **version.sh**: New script for version increments and git commits - **build.sh**: Simplified to focus only on packaging - **BUILD.md**: Updated documentation with new workflow The new workflow allows you to: - Increment versions independently of builds - Commit version changes separately - Build packages without version changes - Test version updates before committing