### PR TITLE
Fix table width to use full available screen space

### DIFF
--- a/wp-tracker.php
+++ b/wp-tracker.php
@@ -235,6 +235,7 @@ class WP_Tracker {
             width: 100%;
             border-collapse: collapse;
             margin-top: 20px;
+            table-layout: auto;
         }
         .wp-tracker-table th,
         .wp-tracker-table td {
@@ -249,26 +250,31 @@ class WP_Tracker {
         }
         .wp-tracker-table .tracker-id {
             width: 120px;
+            min-width: 120px;
             font-family: monospace;
             font-size: 12px;
         }
         .wp-tracker-table .destination-url {
-            width: 300px;
+            min-width: 200px;
             word-break: break-all;
         }
         .wp-tracker-table .clicks {
             width: 80px;
+            min-width: 80px;
             text-align: center;
         }
         .wp-tracker-table .created {
             width: 150px;
+            min-width: 150px;
         }
         .wp-tracker-table .qr-code {
             width: 100px;
+            min-width: 100px;
             text-align: center;
         }
         .wp-tracker-table .actions {
             width: 200px;
+            min-width: 200px;
         }
         .wp-tracker-table .qr-preview {
             width: 80px;
@@ -284,14 +290,6 @@ class WP_Tracker {
             margin: 2px;
             font-size: 11px;
             padding: 4px 8px;
-        }
-        @media (max-width: 1200px) {
-            .wp-tracker-table .destination-url {
-                width: 200px;
-            }
-            .wp-tracker-table .created {
-                width: 120px;
-            }
         }
         </style>';
         

--- a/wp-tracker.php
+++ b/wp-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Tracker
  * Plugin URI: https://github.com/yourusername/wp-tracker
  * Description: Create tracker links that count clicks and redirect to destination URLs
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: Your Name
  * License: GPL v2 or later
  * Text Domain: wp-tracker


### PR DESCRIPTION
This PR fixes the narrow table issue by making the table use the full available width: - **Flexible Layout**: Remove fixed widths and use min-width for flexible columns - **Auto Table Layout**: Let browser calculate optimal column widths - **Full Width**: Table now expands to use all available horizontal space - **Better Proportions**: Fixed columns (ID, Clicks, Created, QR, Actions) have minimum widths, URL column expands naturally - **WordPress-like**: Matches the full-width layout of other WordPress admin tables The table should now fill the entire available width like the Classified Ads plugin.